### PR TITLE
Change feed logic and adjust _index.md for Zola 0.19.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 ![](screenshot.png)
 
 
-A work in progress port of the [hugo-PaperMod](https://github.com/adityatelange/hugo-PaperMod) theme by [@adityatelange](https://github.com/adityatelange) to [Zola](https://www.getzola.org/)
+A work in progress port of the [hugo-PaperMod](https://github.com/adityatelange/hugo-PaperMod) theme by [@adityatelange](https://github.com/adityatelange) to [Zola](https://www.getzola.org/) 
+
+Due to config changes introduced with Zola 0.19, only Zola 0.19.1 and later are currently supported.
 
 Demo @ https://cydave.github.io/zola-theme-papermod/
 
@@ -14,6 +16,7 @@ Demo @ https://cydave.github.io/zola-theme-papermod/
 + [x] Blog post RSS feeds
 + [x] Tags
 + [x] Tag-based RSS feeds
++ [x] Optional: Custom taxonomies
 + [x] Light / Dark theme switching (with configurable default preference)
 + [x] Syntax highlighting for code snippets (Zola's built-in syntax highlighting)
 + [x] Custom navigation
@@ -22,7 +25,7 @@ Demo @ https://cydave.github.io/zola-theme-papermod/
     + [ ] Home-Info Mode
     + [ ] Profile Mode
 + [x] Code copy buttons
-+ [ ] Search page
++ [x] Search page
 + [ ] SEO Metadata
 + [ ] Language switcher (multi-language support)
 

--- a/config.toml
+++ b/config.toml
@@ -2,8 +2,9 @@ author = "cydave"
 title = "PaperMod"
 base_url = "https://cydave.github.io/zola-theme-papermod"
 compile_sass = true
-build_search_index = false
-generate_feed = true
+build_search_index = true 
+generate_feeds = true
+feed_filenames = [ "atom.xml",]
 minify_html = true
 
 

--- a/content/archive/_index.md
+++ b/content/archive/_index.md
@@ -1,4 +1,3 @@
 +++
-date = "2023-05-11T00:00:00"
 template = "archive.html"
 +++

--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -3,6 +3,6 @@ title = "Posts"
 sort_by = "date"
 paginate_by = 5
 insert_anchor_links = "right"
-generate_feed = true
+generate_feeds = true
 transparent = true
 +++

--- a/content/tags/_index.md
+++ b/content/tags/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Tags"
 paginate_by = 10
-generate_feed = true
+generate_feeds = true
 +++
 

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -42,8 +42,10 @@
 #}
 {% endblock %}
 
-{% if config.generate_feed %}
-<link rel="alternate" type={% if config.feed_filename == "atom.xml" %}"application/atom+xml"{% else %}"application/rss+xml"{% endif %} title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
+{% if config.generate_feeds %}
+{% for feed_filename in config.feed_filenames %}
+<link rel="alternate" type={% if feed_filename == "atom.xml" %}"application/atom+xml"{% else %}"application/rss+xml"{% endif %} title="RSS" href="{{ get_url(path=feed_filename) | safe }}">
+{% endfor %}
 {% endif %}
 
 <noscript>

--- a/templates/tags/single.html
+++ b/templates/tags/single.html
@@ -7,13 +7,15 @@
         <a href="{{ current_url }}">{{ term.name }}</a>
     </div>
     <h1>{{ term.name }}
-      <a href="{{ term.permalink ~ config.feed_filename }}" title="RSS" aria-label="RSS">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" height="23">
-        <path d="M4 11a9 9 0 0 1 9 9"></path>
-        <path d="M4 4a16 16 0 0 1 16 16"></path>
-        <circle cx="5" cy="19" r="1"></circle>
-      </svg>
-    </a>
+      {% for feed_filename in config.feed_filenames %}
+      <a href="{{ term.permalink ~ feed_filename }}" title="RSS" aria-label="RSS">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" height="23">
+          <path d="M4 11a9 9 0 0 1 9 9"></path>
+          <path d="M4 4a16 16 0 0 1 16 16"></path>
+          <circle cx="5" cy="19" r="1"></circle>
+        </svg>
+      </a>
+      {% endfor %}
   </h1>
 </header>
 {% for page in term.pages %}

--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -1,0 +1,19 @@
+{% extends "index.html" %}
+{% block main %}
+{% if not title %}
+            {% set title = "All " ~ taxonomy.name | replace(from="_",to=" ") | title %}
+	    {% set css_class = "terms-" ~ taxonomy.name %} 
+{% endif %}
+
+<header class="page-header">
+	<h1>{{ title }}</h1>
+</header>
+
+<ul class="terms-tags {{ css_class }}">
+    {% for term in terms %}
+    <li>
+        <a href="{{ term.permalink }}">{{ term.name }} <sup><strong><sup>{{ term.page_count }}</sup></strong></sup> </a>
+    </li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -1,12 +1,16 @@
-{% extends 'index.html' %}
+{% extends "index.html" %}
 {% block main %}
+{% set taxonomy_title = taxonomy.name | replace(from="_",to=" ") | title %}
+
 <header class="page-header">
-    <div class="breadcrumbs">
-        <a href="{{ config.base_url }}">Home</a>
+    <div class="breadcrumbs"> 
+        <a href="{{ config.base_url }}">Home</a>&nbsp;»&nbsp;
+	<a href="{{ config.base_url }}/{{ taxonomy.name }}">{{ taxonomy_title }}</a>&nbsp;»&nbsp;
+        <a href="{{ current_url }}">{{ term.name }}</a>
     </div>
-    <h1>{{ section.title }}
+    <h1>{{ term.name | replace(from="_",to=" ") | title }}
       {% for feed_filename in config.feed_filenames %}
-      <a href="{{ get_url(path=feed_filename, trailingslash=false) | safe }}" title="RSS" aria-label="RSS">
+      <a href="{{ term.permalink ~ feed_filename }}" title="RSS" aria-label="RSS">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" height="23">
           <path d="M4 11a9 9 0 0 1 9 9"></path>
           <path d="M4 4a16 16 0 0 1 16 16"></path>
@@ -16,7 +20,7 @@
       {% endfor %}
   </h1>
 </header>
-{% for page in paginator.pages %}
+{% for page in term.pages %}
 <article class="post-entry">
   <header class="entry-header">
       <h2>{{ page.title }}</h2>


### PR DESCRIPTION
This pull request makes Zola PaperMod work with Zola 0.19.1. Unfortunately, it also breaks Zola 0.18 and before - this can't be avoided.

Also adding generic taxonomy templates that make it possible to use this on sites that, e.g., also have a "categories" taxonomy.

I've also updated README.md to reflect the changes introduced with this and previous commits.