### PR TITLE
fix search page light mode background color

### DIFF
--- a/static/css/override.css
+++ b/static/css/override.css
@@ -30,3 +30,9 @@
 .post-content pre code > table td:nth-child(2) {
     width: 92%;
 }
+#searchbox input {
+    background-color: var(--theme);
+}
+.dark #searchbox input {
+    background-color: var(--tertiary);
+}

--- a/templates/search.html
+++ b/templates/search.html
@@ -6,7 +6,7 @@
     {% include "partials/head.html" %}
     {% endblock %}
 </head>
-<body class="{% if section or term or taxonomy %}list {% endif %}{% if config.extra.papermod.theme == 'dark' %} dark{% endif %}" id="top">
+<body class="list{% if config.extra.papermod.theme == 'dark' %} dark{% endif %}" id="top">
     {% block header %}
     {% include "partials/header.html" %}
     {% endblock %}


### PR DESCRIPTION
Light mode has inconsistent background color because `/search` doesn’t satisfy the `if section or term or taxonomy` condition, so it never gets `.list` in the `<body>` class. As a result, the search page light mode background is pure white instead of the off-white background of other pages.

This is the minimal change to fix the issue by replacing the if condition on the body tag in search.html. This gets the job done but a better solution might be to stop using the list class to carry this information.

I also made the search box white in light mode to improve contrast and draw the eye to the central element of the page.